### PR TITLE
Check for malformed URL created from function

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM php:7.1
 
+ARG COMPOSER_FLAGS="--no-interaction"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -14,9 +15,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /code
 
 # Initialize
-COPY . /code/
 COPY php.ini /usr/local/etc/php/
 
-RUN composer install --no-interaction
+## Composer - deps always cached unless changed
+# First copy only composer files
+COPY composer.* /code/
+# Download dependencies, but don't run scripts or init autoloaders as the app is missing
+RUN composer install $COMPOSER_FLAGS --no-scripts --no-autoloader
+# copy rest of the app
+COPY . /code/
+# run normal composer - all deps are cached already
+RUN composer install $COMPOSER_FLAGS
 
 CMD php /code/run.php --data=/data

--- a/tests/Config/ApiTest.php
+++ b/tests/Config/ApiTest.php
@@ -165,4 +165,22 @@ class ApiTest extends TestCase
         self::assertEquals(['foo' => 'bar', 'oauth2_access_token' => 'baz'], $request->getQuery()->toArray());
         self::assertEquals(['Host' => ['example.com']], $request->getHeaders());
     }
+
+    public function testInvalidFunctionBaseUrlThrowsUserException()
+    {
+        $apiConfig = [
+            "baseUrl" => [
+                "function" => "concat",
+                "args" => [
+                    "http://",
+                    "/087-function-baseurl/",
+                ],
+            ],
+        ];
+        $this->expectException(UserException::class);
+        $this->expectExceptionMessage(
+            'The "baseUrl" attribute in API configuration resulted in an invalid URL (http:///087-function-baseurl/)'
+        );
+        new Api(new NullLogger(), $apiConfig, [], []);
+    }
 }


### PR DESCRIPTION
Fixes #97 

Could be tested with following config:

```
{
    "parameters": {
        "api": {
            "baseUrl": {
                "function": "concat",
                "args": [
                    "http://",
                    "/invalid-url/"
                ]
            }
        },
        "config": {
            "debug": true,
            "outputBucket": "mock-server",
            "jobs": [
                {
                    "endpoint": "users"
                }
            ]
        }
    }
}

```

