### PR TITLE
feat: add a dummy user and group

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,8 @@ COPY . /code/
 # run normal composer - all deps are cached already
 RUN composer install $COMPOSER_FLAGS
 
+# add a a group with gid 501 and user with uid 501
+RUN groupadd app -g 501
+RUN useradd app -u 501 -g 501
+
 CMD php /code/run.php --data=/data


### PR DESCRIPTION
#Přidal jsem uživatele s uid 501 a groupu 501. Předpokládám, že `uid:gid` (deploy:apache) na instancích bude furt stejny.  Jiný řešení se mi nepodařilo najít :-( Přes `sudo` to nejde (pustit pod neznámým uživatelem), tak jediný jiný řešení mě napadlo kontejner pustit pod rootem, v kontejneru vytvořit uživatele s `uid:gid` předaným kontejneru zvenčí (místo přímýho puštění pod `uid:gid`) a `su`čknutí na něj. `uid:gid` by se předalo přes ENVy a tak by to mohlo bejt dynamický. 