### PR TITLE
fix: named apis and id configurations

### DIFF
--- a/src/Executor.php
+++ b/src/Executor.php
@@ -142,7 +142,7 @@ class Executor
             $fs->remove($folders);
         }
 
-        MissingTableHelper::checkConfigs($configs, $arguments['data']);
+        MissingTableHelper::checkConfigs($configs, $arguments['data'], $configuration->getApi([])->getName());
         $metadata['time']['previousStart'] = $metadata['time']['currentStart'];
         unset($metadata['time']['currentStart']);
         $configuration->saveConfigMetadata($metadata);

--- a/src/Executor.php
+++ b/src/Executor.php
@@ -142,7 +142,7 @@ class Executor
             $fs->remove($folders);
         }
 
-        MissingTableHelper::checkConfigs($configs, $arguments['data'], $configuration->getApi([])->getName());
+        MissingTableHelper::checkConfigs($configs, $arguments['data'], $configuration);
         $metadata['time']['previousStart'] = $metadata['time']['currentStart'];
         unset($metadata['time']['currentStart']);
         $configuration->saveConfigMetadata($metadata);

--- a/src/MissingTableHelper.php
+++ b/src/MissingTableHelper.php
@@ -8,19 +8,19 @@ use Keboola\GenericExtractor\Exception\UserException;
 
 class MissingTableHelper
 {
-    public static function checkConfigs($configs, $dataDir, $name)
+    public static function checkConfigs($configs, $dataDir, Extractor $configuration)
     {
-        if (!$name) {
-            $name = "generic";
-        }
         foreach ($configs as $config) {
+            $api = $configuration->getApi($config->getAttributes());
+
             if (!empty($config->getAttribute('outputBucket'))) {
                 $outputBucket = $config->getAttribute('outputBucket');
             } elseif ($config->getAttribute('id')) {
-                $outputBucket = 'ex-api-' . $name . "-" . $config->getAttribute('id');
+                $outputBucket = 'ex-api-' . $api->getName() . "-" . $config->getAttribute('id');
             } else {
-                $outputBucket = '';
+                $outputBucket = "__kbc_default";
             }
+            $outputBucket = $outputBucket == "__kbc_default" ? null : $outputBucket;
 
             if ($config->getAttribute('mappings')) {
                 foreach ($config->getAttribute('mappings') as $name => $mapping) {

--- a/src/MissingTableHelper.php
+++ b/src/MissingTableHelper.php
@@ -3,17 +3,29 @@
 namespace Keboola\GenericExtractor;
 
 use Keboola\Csv\CsvFile;
+use Keboola\GenericExtractor\Configuration\Extractor;
 use Keboola\GenericExtractor\Exception\UserException;
 
 class MissingTableHelper
 {
-    public static function checkConfigs($configs, $dataDir)
+    public static function checkConfigs($configs, $dataDir, $name)
     {
+        if (!$name) {
+            $name = "generic";
+        }
         foreach ($configs as $config) {
+            if (!empty($config->getAttribute('outputBucket'))) {
+                $outputBucket = $config->getAttribute('outputBucket');
+            } elseif ($config->getAttribute('id')) {
+                $outputBucket = 'ex-api-' . $name . "-" . $config->getAttribute('id');
+            } else {
+                $outputBucket = '';
+            }
+
             if ($config->getAttribute('mappings')) {
                 foreach ($config->getAttribute('mappings') as $name => $mapping) {
-                    if ($config->getAttribute('outputBucket')) {
-                        $destinationBase = $dataDir . '/out/tables/' . $config->getAttribute('outputBucket') . '.';
+                    if ($outputBucket) {
+                        $destinationBase = $dataDir . '/out/tables/' . $outputBucket . '.';
                     } else {
                         $destinationBase = $dataDir . '/out/tables/';
                     }

--- a/src/MissingTableHelper.php
+++ b/src/MissingTableHelper.php
@@ -18,9 +18,8 @@ class MissingTableHelper
             } elseif ($config->getAttribute('id')) {
                 $outputBucket = 'ex-api-' . $api->getName() . "-" . $config->getAttribute('id');
             } else {
-                $outputBucket = "__kbc_default";
+                $outputBucket = '';
             }
-            $outputBucket = $outputBucket == "__kbc_default" ? null : $outputBucket;
 
             if ($config->getAttribute('mappings')) {
                 foreach ($config->getAttribute('mappings') as $name => $mapping) {

--- a/tests/MissingTableHelperTest.php
+++ b/tests/MissingTableHelperTest.php
@@ -85,7 +85,7 @@ class MissingTableHelperTest extends TestCase
         mkdir($temp->getTmpFolder() . '/out/');
         $baseDir = $temp->getTmpFolder() . '/out/tables/';
         mkdir($baseDir);
-        MissingTableHelper::checkConfigs($configs, $temp->getTmpFolder());
+        MissingTableHelper::checkConfigs($configs, $temp->getTmpFolder(), '');
         self::assertFileExists($baseDir . 'mock-server.primary-address');
         self::assertFileExists($baseDir . 'mock-server.primary-address.manifest');
         self::assertFileExists($baseDir . 'mock-server.user-contact');
@@ -161,7 +161,7 @@ class MissingTableHelperTest extends TestCase
         mkdir($baseDir);
         file_put_contents($baseDir . 'mock-server.users', 'foo');
         file_put_contents($baseDir . 'mock-server.users.manifest', 'bar');
-        MissingTableHelper::checkConfigs($configs, $temp->getTmpFolder());
+        MissingTableHelper::checkConfigs($configs, $temp->getTmpFolder(), '');
         self::assertFileExists($baseDir . 'mock-server.users');
         self::assertFileExists($baseDir . 'mock-server.users.manifest');
         self::assertEquals('foo', file_get_contents($baseDir . 'mock-server.users'));
@@ -189,7 +189,7 @@ class MissingTableHelperTest extends TestCase
         mkdir($temp->getTmpFolder() . '/out/');
         $baseDir = $temp->getTmpFolder() . '/out/tables/';
         mkdir($baseDir);
-        MissingTableHelper::checkConfigs($configs, $temp->getTmpFolder());
+        MissingTableHelper::checkConfigs($configs, $temp->getTmpFolder(), '');
         self::assertFileNotExists($baseDir . 'mock-server.users');
         self::assertFileNotExists($baseDir . 'mock-server.users.manifest');
     }
@@ -227,7 +227,7 @@ class MissingTableHelperTest extends TestCase
         mkdir($temp->getTmpFolder() . '/out/');
         $baseDir = $temp->getTmpFolder() . '/out/tables/';
         mkdir($baseDir);
-        MissingTableHelper::checkConfigs($configs, $temp->getTmpFolder());
+        MissingTableHelper::checkConfigs($configs, $temp->getTmpFolder(), '');
         self::assertFileExists($baseDir . 'mock-server.user-contact');
         self::assertFileExists($baseDir . 'mock-server.user-contact.manifest');
         self::assertFileExists($baseDir . 'mock-server.users');
@@ -286,7 +286,7 @@ class MissingTableHelperTest extends TestCase
         mkdir($temp->getTmpFolder() . '/out/');
         $baseDir = $temp->getTmpFolder() . '/out/tables/';
         mkdir($baseDir);
-        MissingTableHelper::checkConfigs($configs, $temp->getTmpFolder());
+        MissingTableHelper::checkConfigs($configs, $temp->getTmpFolder(), '');
         self::assertFileExists($baseDir . 'user-contact');
         self::assertFileExists($baseDir . 'user-contact.manifest');
         self::assertFileExists($baseDir . 'users');
@@ -309,6 +309,124 @@ class MissingTableHelperTest extends TestCase
         self::assertEquals(
             ['incremental' => false],
             json_decode(file_get_contents($baseDir . 'users.manifest'), true)
+        );
+    }
+
+    public function testMissingBucketPresentIdPresentName()
+    {
+        $temp = new Temp();
+        $config = [
+            'id' => 'config-id',
+            'jobs' => [
+                [
+                    'endpoint' => 'users',
+                    'dataType' => 'users',
+                ],
+            ],
+            'mappings' => [
+                'users' => [
+                    'id' => 'id',
+                    'name' => 'name',
+                    'contacts' => [
+                        'type' => 'table',
+                        'destination' => 'user-contact',
+                        'tableMapping' => [
+                            'email' => 'email',
+                            'phone' => 'phone',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $configs = [new Config($config)];
+        $temp->initRunFolder();
+
+        mkdir($temp->getTmpFolder() . '/out/');
+        $baseDir = $temp->getTmpFolder() . '/out/tables/';
+        mkdir($baseDir);
+        MissingTableHelper::checkConfigs($configs, $temp->getTmpFolder(), 'testName');
+        self::assertFileExists($baseDir . 'ex-api-testName-config-id.user-contact');
+        self::assertFileExists($baseDir . 'ex-api-testName-config-id.user-contact.manifest');
+        self::assertFileExists($baseDir . 'ex-api-testName-config-id.users');
+        self::assertFileExists($baseDir . 'ex-api-testName-config-id.users.manifest');
+
+        self::assertEquals(
+            '"email","phone","users_pk"',
+            trim(file_get_contents($baseDir . 'ex-api-testName-config-id.user-contact'))
+        );
+        self::assertEquals(
+            [
+                'incremental' => false,
+            ],
+            json_decode(file_get_contents($baseDir . 'ex-api-testName-config-id.user-contact.manifest'), true)
+        );
+        self::assertEquals(
+            '"id","name"',
+            trim(file_get_contents($baseDir . 'ex-api-testName-config-id.users'))
+        );
+        self::assertEquals(
+            ['incremental' => false],
+            json_decode(file_get_contents($baseDir . 'ex-api-testName-config-id.users.manifest'), true)
+        );
+    }
+
+    public function testMissingBucketPresentIdMissingName()
+    {
+        $temp = new Temp();
+        $config = [
+            'id' => 'config-id',
+            'jobs' => [
+                [
+                    'endpoint' => 'users',
+                    'dataType' => 'users',
+                ],
+            ],
+            'mappings' => [
+                'users' => [
+                    'id' => 'id',
+                    'name' => 'name',
+                    'contacts' => [
+                        'type' => 'table',
+                        'destination' => 'user-contact',
+                        'tableMapping' => [
+                            'email' => 'email',
+                            'phone' => 'phone',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $configs = [new Config($config)];
+        $temp->initRunFolder();
+
+        mkdir($temp->getTmpFolder() . '/out/');
+        $baseDir = $temp->getTmpFolder() . '/out/tables/';
+        mkdir($baseDir);
+        MissingTableHelper::checkConfigs($configs, $temp->getTmpFolder(), '');
+        self::assertFileExists($baseDir . 'ex-api-generic-config-id.user-contact');
+        self::assertFileExists($baseDir . 'ex-api-generic-config-id.user-contact.manifest');
+        self::assertFileExists($baseDir . 'ex-api-generic-config-id.users');
+        self::assertFileExists($baseDir . 'ex-api-generic-config-id.users.manifest');
+
+        self::assertEquals(
+            '"email","phone","users_pk"',
+            trim(file_get_contents($baseDir . 'ex-api-generic-config-id.user-contact'))
+        );
+        self::assertEquals(
+            [
+                'incremental' => false,
+            ],
+            json_decode(file_get_contents($baseDir . 'ex-api-generic-config-id.user-contact.manifest'), true)
+        );
+        self::assertEquals(
+            '"id","name"',
+            trim(file_get_contents($baseDir . 'ex-api-generic-config-id.users'))
+        );
+        self::assertEquals(
+            ['incremental' => false],
+            json_decode(file_get_contents($baseDir . 'ex-api-generic-config-id.users.manifest'), true)
         );
     }
 }

--- a/tests/MissingTableHelperTest.php
+++ b/tests/MissingTableHelperTest.php
@@ -2,10 +2,12 @@
 
 namespace Keboola\GenericExtractor\Tests;
 
+use Keboola\GenericExtractor\Configuration\Extractor;
 use Keboola\GenericExtractor\MissingTableHelper;
 use Keboola\Juicer\Config\Config;
 use Keboola\Temp\Temp;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
 
 class MissingTableHelperTest extends TestCase
 {
@@ -13,64 +15,69 @@ class MissingTableHelperTest extends TestCase
     {
         $temp = new Temp();
         $config = [
-            'jobs' => [
-                [
-                    'endpoint' => 'users',
-                    'dataType' => 'users',
-                ],
-            ],
-            'outputBucket' => 'mock-server',
-            'incremental' => true,
-            'mappings' => [
-                'users' => [
-                    'id' => [
-                        'type' => 'column',
-                        'mapping' => [
-                            'destination' => 'id',
-                            'primaryKey' => true,
+            'parameters' => [
+                'api' => ['baseUrl' => 'https://dummy'],
+                'config' => [
+                    'jobs' => [
+                        [
+                            'endpoint' => 'users',
+                            'dataType' => 'users',
                         ],
                     ],
-                    'name' => [
-                        'mapping' => [
-                            'destination' => 'name',
-                        ],
-                    ],
-                    'contacts' => [
-                        'type' => 'table',
-                        'destination' => 'user-contact',
-                        'parentKey' => [
-                            'primaryKey' => true,
-                            'destination' => 'userId',
-                        ],
-                        'tableMapping' => [
-                            'email' => [
+                    'outputBucket' => 'mock-server',
+                    'incremental' => true,
+                    'mappings' => [
+                        'users' => [
+                            'id' => [
                                 'type' => 'column',
                                 'mapping' => [
-                                    'destination' => 'email',
+                                    'destination' => 'id',
+                                    'primaryKey' => true,
                                 ],
                             ],
-                            'phone' => [
-                                'type' => 'column',
+                            'name' => [
                                 'mapping' => [
-                                    'destination' => 'phone',
+                                    'destination' => 'name',
                                 ],
                             ],
-                        ],
-                    ],
-                    'contacts.addresses.0' => [
-                        'type' => 'table',
-                        'destination' => 'primary-address',
-                        'tableMapping' => [
-                            'street' => [
-                                'type' => 'column',
-                                'mapping' => [
-                                    'destination' => 'street',
+                            'contacts' => [
+                                'type' => 'table',
+                                'destination' => 'user-contact',
+                                'parentKey' => [
+                                    'primaryKey' => true,
+                                    'destination' => 'userId',
+                                ],
+                                'tableMapping' => [
+                                    'email' => [
+                                        'type' => 'column',
+                                        'mapping' => [
+                                            'destination' => 'email',
+                                        ],
+                                    ],
+                                    'phone' => [
+                                        'type' => 'column',
+                                        'mapping' => [
+                                            'destination' => 'phone',
+                                        ],
+                                    ],
                                 ],
                             ],
-                            'country' => [
-                                'type' => 'column',
-                                'mapping' => [
-                                    'destination' => 'country',
+                            'contacts.addresses.0' => [
+                                'type' => 'table',
+                                'destination' => 'primary-address',
+                                'tableMapping' => [
+                                    'street' => [
+                                        'type' => 'column',
+                                        'mapping' => [
+                                            'destination' => 'street',
+                                        ],
+                                    ],
+                                    'country' => [
+                                        'type' => 'column',
+                                        'mapping' => [
+                                            'destination' => 'country',
+                                        ],
+                                    ],
                                 ],
                             ],
                         ],
@@ -78,14 +85,15 @@ class MissingTableHelperTest extends TestCase
                 ],
             ],
         ];
-
-        $configs = [new Config($config)];
         $temp->initRunFolder();
 
         mkdir($temp->getTmpFolder() . '/out/');
         $baseDir = $temp->getTmpFolder() . '/out/tables/';
         mkdir($baseDir);
-        MissingTableHelper::checkConfigs($configs, $temp->getTmpFolder(), '');
+        file_put_contents($temp->getTmpFolder() . '/config.json', json_encode($config));
+        $configuration = new Extractor($temp->getTmpFolder(), new NullLogger());
+        $configs = $configuration->getMultipleConfigs();
+        MissingTableHelper::checkConfigs($configs, $temp->getTmpFolder(), $configuration);
         self::assertFileExists($baseDir . 'mock-server.primary-address');
         self::assertFileExists($baseDir . 'mock-server.primary-address.manifest');
         self::assertFileExists($baseDir . 'mock-server.user-contact');
@@ -127,41 +135,47 @@ class MissingTableHelperTest extends TestCase
     {
         $temp = new Temp();
         $config = [
-            'jobs' => [
-                [
-                    'endpoint' => 'users',
-                    'dataType' => 'users',
-                ],
-            ],
-            'outputBucket' => 'mock-server',
-            'incremental' => true,
-            'mappings' => [
-                'users' => [
-                    'id' => [
-                        'type' => 'column',
-                        'mapping' => [
-                            'destination' => 'id',
-                            'primaryKey' => true,
+            'parameters' => [
+                'api' => ['baseUrl' => 'https://dummy'],
+                'config' => [
+                    'jobs' => [
+                        [
+                            'endpoint' => 'users',
+                            'dataType' => 'users',
                         ],
                     ],
-                    'name' => [
-                        'mapping' => [
-                            'destination' => 'name',
+                    'outputBucket' => 'mock-server',
+                    'incremental' => true,
+                    'mappings' => [
+                        'users' => [
+                            'id' => [
+                                'type' => 'column',
+                                'mapping' => [
+                                    'destination' => 'id',
+                                    'primaryKey' => true,
+                                ],
+                            ],
+                            'name' => [
+                                'mapping' => [
+                                    'destination' => 'name',
+                                ],
+                            ],
                         ],
                     ],
                 ],
             ],
         ];
-
-        $configs = [new Config($config)];
         $temp->initRunFolder();
 
         mkdir($temp->getTmpFolder() . '/out/');
         $baseDir = $temp->getTmpFolder() . '/out/tables/';
         mkdir($baseDir);
+        file_put_contents($temp->getTmpFolder() . '/config.json', json_encode($config));
+        $configuration = new Extractor($temp->getTmpFolder(), new NullLogger());
+        $configs = $configuration->getMultipleConfigs();
         file_put_contents($baseDir . 'mock-server.users', 'foo');
         file_put_contents($baseDir . 'mock-server.users.manifest', 'bar');
-        MissingTableHelper::checkConfigs($configs, $temp->getTmpFolder(), '');
+        MissingTableHelper::checkConfigs($configs, $temp->getTmpFolder(), $configuration);
         self::assertFileExists($baseDir . 'mock-server.users');
         self::assertFileExists($baseDir . 'mock-server.users.manifest');
         self::assertEquals('foo', file_get_contents($baseDir . 'mock-server.users'));
@@ -172,24 +186,30 @@ class MissingTableHelperTest extends TestCase
     {
         $temp = new Temp();
         $config = [
-            'jobs' => [
-                [
-                    'endpoint' => 'users',
-                    'dataType' => 'users',
+            'parameters' => [
+                'api' => ['baseUrl' => 'https://dummy'],
+                'config' => [
+                    'jobs' => [
+                        [
+                            'endpoint' => 'users',
+                            'dataType' => 'users',
+                        ],
+                    ],
+                    'outputBucket' => 'mock-server',
+                    'incremental' => true,
+                    'mappings' => null,
                 ],
             ],
-            'outputBucket' => 'mock-server',
-            'incremental' => true,
-            'mappings' => null,
         ];
-
-        $configs = [new Config($config)];
         $temp->initRunFolder();
 
         mkdir($temp->getTmpFolder() . '/out/');
         $baseDir = $temp->getTmpFolder() . '/out/tables/';
         mkdir($baseDir);
-        MissingTableHelper::checkConfigs($configs, $temp->getTmpFolder(), '');
+        file_put_contents($temp->getTmpFolder() . '/config.json', json_encode($config));
+        $configuration = new Extractor($temp->getTmpFolder(), new NullLogger());
+        $configs = $configuration->getMultipleConfigs();
+        MissingTableHelper::checkConfigs($configs, $temp->getTmpFolder(), $configuration);
         self::assertFileNotExists($baseDir . 'mock-server.users');
         self::assertFileNotExists($baseDir . 'mock-server.users.manifest');
     }
@@ -198,36 +218,43 @@ class MissingTableHelperTest extends TestCase
     {
         $temp = new Temp();
         $config = [
-            'jobs' => [
-                [
-                    'endpoint' => 'users',
-                    'dataType' => 'users',
-                ],
-            ],
-            'outputBucket' => 'mock-server',
-            'mappings' => [
-                'users' => [
-                    'id' => 'id',
-                    'name' => 'name',
-                    'contacts' => [
-                        'type' => 'table',
-                        'destination' => 'user-contact',
-                        'tableMapping' => [
-                            'email' => 'email',
-                            'phone' => 'phone',
+            'parameters' => [
+                'api' => ['baseUrl' => 'https://dummy'],
+                'config' => [
+                    'jobs' => [
+                        [
+                            'endpoint' => 'users',
+                            'dataType' => 'users',
+                        ],
+                    ],
+                    'outputBucket' => 'mock-server',
+                    'mappings' => [
+                        'users' => [
+                            'id' => 'id',
+                            'name' => 'name',
+                            'contacts' => [
+                                'type' => 'table',
+                                'destination' => 'user-contact',
+                                'tableMapping' => [
+                                    'email' => 'email',
+                                    'phone' => 'phone',
+                                ],
+                            ],
                         ],
                     ],
                 ],
             ],
         ];
-
-        $configs = [new Config($config)];
         $temp->initRunFolder();
 
         mkdir($temp->getTmpFolder() . '/out/');
         $baseDir = $temp->getTmpFolder() . '/out/tables/';
         mkdir($baseDir);
-        MissingTableHelper::checkConfigs($configs, $temp->getTmpFolder(), '');
+        file_put_contents($temp->getTmpFolder() . '/config.json', json_encode($config));
+        $configuration = new Extractor($temp->getTmpFolder(), new NullLogger());
+        $configs = $configuration->getMultipleConfigs();
+        MissingTableHelper::checkConfigs($configs, $temp->getTmpFolder(), $configuration);
+
         self::assertFileExists($baseDir . 'mock-server.user-contact');
         self::assertFileExists($baseDir . 'mock-server.user-contact.manifest');
         self::assertFileExists($baseDir . 'mock-server.users');
@@ -258,35 +285,42 @@ class MissingTableHelperTest extends TestCase
     {
         $temp = new Temp();
         $config = [
-            'jobs' => [
-                [
-                    'endpoint' => 'users',
-                    'dataType' => 'users',
-                ],
-            ],
-            'mappings' => [
-                'users' => [
-                    'id' => 'id',
-                    'name' => 'name',
-                    'contacts' => [
-                        'type' => 'table',
-                        'destination' => 'user-contact',
-                        'tableMapping' => [
-                            'email' => 'email',
-                            'phone' => 'phone',
+            'parameters' => [
+                'api' => ['baseUrl' => 'https://dummy'],
+                'config' => [
+                    'jobs' => [
+                        [
+                            'endpoint' => 'users',
+                            'dataType' => 'users',
+                        ],
+                    ],
+                    'mappings' => [
+                        'users' => [
+                            'id' => 'id',
+                            'name' => 'name',
+                            'contacts' => [
+                                'type' => 'table',
+                                'destination' => 'user-contact',
+                                'tableMapping' => [
+                                    'email' => 'email',
+                                    'phone' => 'phone',
+                                ],
+                            ],
                         ],
                     ],
                 ],
             ],
         ];
-
-        $configs = [new Config($config)];
         $temp->initRunFolder();
 
         mkdir($temp->getTmpFolder() . '/out/');
         $baseDir = $temp->getTmpFolder() . '/out/tables/';
         mkdir($baseDir);
-        MissingTableHelper::checkConfigs($configs, $temp->getTmpFolder(), '');
+        file_put_contents($temp->getTmpFolder() . '/config.json', json_encode($config));
+        $configuration = new Extractor($temp->getTmpFolder(), new NullLogger());
+        $configs = $configuration->getMultipleConfigs();
+        MissingTableHelper::checkConfigs($configs, $temp->getTmpFolder(), $configuration);
+
         self::assertFileExists($baseDir . 'user-contact');
         self::assertFileExists($baseDir . 'user-contact.manifest');
         self::assertFileExists($baseDir . 'users');
@@ -316,36 +350,43 @@ class MissingTableHelperTest extends TestCase
     {
         $temp = new Temp();
         $config = [
-            'id' => 'config-id',
-            'jobs' => [
-                [
-                    'endpoint' => 'users',
-                    'dataType' => 'users',
-                ],
-            ],
-            'mappings' => [
-                'users' => [
-                    'id' => 'id',
-                    'name' => 'name',
-                    'contacts' => [
-                        'type' => 'table',
-                        'destination' => 'user-contact',
-                        'tableMapping' => [
-                            'email' => 'email',
-                            'phone' => 'phone',
+            'parameters' => [
+                'api' => ['baseUrl' => 'https://dummy', 'name' => 'testName'],
+                'config' => [
+                    'id' => 'config-id',
+                    'jobs' => [
+                        [
+                            'endpoint' => 'users',
+                            'dataType' => 'users',
+                        ],
+                    ],
+                    'mappings' => [
+                        'users' => [
+                            'id' => 'id',
+                            'name' => 'name',
+                            'contacts' => [
+                                'type' => 'table',
+                                'destination' => 'user-contact',
+                                'tableMapping' => [
+                                    'email' => 'email',
+                                    'phone' => 'phone',
+                                ],
+                            ],
                         ],
                     ],
                 ],
             ],
         ];
-
-        $configs = [new Config($config)];
         $temp->initRunFolder();
 
         mkdir($temp->getTmpFolder() . '/out/');
         $baseDir = $temp->getTmpFolder() . '/out/tables/';
         mkdir($baseDir);
-        MissingTableHelper::checkConfigs($configs, $temp->getTmpFolder(), 'testName');
+        file_put_contents($temp->getTmpFolder() . '/config.json', json_encode($config));
+        $configuration = new Extractor($temp->getTmpFolder(), new NullLogger());
+        $configs = $configuration->getMultipleConfigs();
+        MissingTableHelper::checkConfigs($configs, $temp->getTmpFolder(), $configuration);
+
         self::assertFileExists($baseDir . 'ex-api-testName-config-id.user-contact');
         self::assertFileExists($baseDir . 'ex-api-testName-config-id.user-contact.manifest');
         self::assertFileExists($baseDir . 'ex-api-testName-config-id.users');
@@ -375,36 +416,43 @@ class MissingTableHelperTest extends TestCase
     {
         $temp = new Temp();
         $config = [
-            'id' => 'config-id',
-            'jobs' => [
-                [
-                    'endpoint' => 'users',
-                    'dataType' => 'users',
-                ],
-            ],
-            'mappings' => [
-                'users' => [
-                    'id' => 'id',
-                    'name' => 'name',
-                    'contacts' => [
-                        'type' => 'table',
-                        'destination' => 'user-contact',
-                        'tableMapping' => [
-                            'email' => 'email',
-                            'phone' => 'phone',
+            'parameters' => [
+                'api' => ['baseUrl' => 'https://dummy'],
+                'config' => [
+                    'id' => 'config-id',
+                    'jobs' => [
+                        [
+                            'endpoint' => 'users',
+                            'dataType' => 'users',
+                        ],
+                    ],
+                    'mappings' => [
+                        'users' => [
+                            'id' => 'id',
+                            'name' => 'name',
+                            'contacts' => [
+                                'type' => 'table',
+                                'destination' => 'user-contact',
+                                'tableMapping' => [
+                                    'email' => 'email',
+                                    'phone' => 'phone',
+                                ],
+                            ],
                         ],
                     ],
                 ],
             ],
         ];
-
-        $configs = [new Config($config)];
         $temp->initRunFolder();
 
         mkdir($temp->getTmpFolder() . '/out/');
         $baseDir = $temp->getTmpFolder() . '/out/tables/';
         mkdir($baseDir);
-        MissingTableHelper::checkConfigs($configs, $temp->getTmpFolder(), '');
+        file_put_contents($temp->getTmpFolder() . '/config.json', json_encode($config));
+        $configuration = new Extractor($temp->getTmpFolder(), new NullLogger());
+        $configs = $configuration->getMultipleConfigs();
+        MissingTableHelper::checkConfigs($configs, $temp->getTmpFolder(), $configuration);
+
         self::assertFileExists($baseDir . 'ex-api-generic-config-id.user-contact');
         self::assertFileExists($baseDir . 'ex-api-generic-config-id.user-contact.manifest');
         self::assertFileExists($baseDir . 'ex-api-generic-config-id.users');


### PR DESCRIPTION
except for `outputBucket` property, the output bucket name can also be generated by from id of the configuration or name of the api:
https://github.com/keboola/generic-extractor/blob/master/src/Executor.php#L81-L88

https://github.com/keboola/generic-extractor/blob/master/src/Configuration/Api.php#L85

https://github.com/keboola/generic-extractor/blob/master/src/Configuration/Api.php#L26

3.6.0 success job https://connection.keboola.com/admin/projects/578/jobs/585485812?q=
3.7.2 failed job https://connection.keboola.com/admin/projects/578/jobs/585657670?q=
PR#116 success job https://connection.keboola.com/admin/projects/578/jobs/585651784?q=