### PR TITLE
Add "GeoTrustRSACA2018" and "DigiCertGlobalRootCA" to trusted ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && curl -sS https://getcomposer.org/installer | php \
     && ln -s /root/composer.phar /usr/local/bin/composer
 
+## Add additional certificates
+## Certificates downloaded from: https://www.digicert.com/digicert-root-certificates.htm
+##
+## From "man update-ca-certificates":
+## > Furthermore all certificates with a .crt  extension found below
+## > /usr/local/share/ca-certificates are also included as implicitly trusted.
+RUN curl https://cacerts.digicert.com/GeoTrustRSACA2018.crt.pem --output /usr/local/share/ca-certificates/GeoTrustRSACA2018.crt \
+  && curl https://cacerts.digicert.com/DigiCertGlobalRootCA.crt.pem --output /usr/local/share/ca-certificates/DigiCertGlobalRootCA.crt \
+  && update-ca-certificates
+
 WORKDIR /code
 
 # Initialize


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/COM-323

Changes:

- Add "GeoTrustRSACA2018" and "DigiCertGlobalRootCA" to trusted ca-certificates

---
Stahuje sa to rovno z tej sajty. Berem to skor ako hotfix. Ak v buducnosti pribudne nieco dalsie, kludne by som hlasoval za "multi-stage" build, kde sa z inej stage sitahnu vsetky dodatocne certifikaty, co pojdu do `/usr/local/share/ca-certificates/`