### PR TITLE
Update juicer

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -758,16 +758,16 @@
         },
         {
             "name": "keboola/juicer",
-            "version": "5.0.6",
+            "version": "5.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/juicer.git",
-                "reference": "287d84d42a02e18d4629399a29f25a912b9ebb3a"
+                "reference": "cef6f9d3c7ae10e432f5a88cb21582be6474ad53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/juicer/zipball/287d84d42a02e18d4629399a29f25a912b9ebb3a",
-                "reference": "287d84d42a02e18d4629399a29f25a912b9ebb3a",
+                "url": "https://api.github.com/repos/keboola/juicer/zipball/cef6f9d3c7ae10e432f5a88cb21582be6474ad53",
+                "reference": "cef6f9d3c7ae10e432f5a88cb21582be6474ad53",
                 "shasum": ""
             },
             "require": {
@@ -815,9 +815,9 @@
             ],
             "support": {
                 "issues": "https://github.com/keboola/juicer/issues",
-                "source": "https://github.com/keboola/juicer/tree/5.0.6"
+                "source": "https://github.com/keboola/juicer/tree/5.0.7"
             },
-            "time": "2022-11-25T09:07:18+00:00"
+            "time": "2022-11-30T10:29:53+00:00"
         },
         {
             "name": "keboola/php-csvtable",


### PR DESCRIPTION
Follow-up to: https://github.com/keboola/generic-extractor/pull/168

Changes:

- Update juicer to allow numeric endpoints