### PR TITLE
Check headers for invalid values and its test

### DIFF
--- a/tests/phpunit/FunctionalTest.php
+++ b/tests/phpunit/FunctionalTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\GenericExtractor\Tests;
+
+use Keboola\GenericExtractor\Tests\Traits\RmDirTrait;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+class FunctionalTest extends TestCase
+{
+    use RmDirTrait;
+
+    private array $rmDirs;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->rmDirs = [];
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        // Remove out dirs
+        foreach ($this->rmDirs as $dir) {
+            $this->rmDir($dir);
+        }
+    }
+
+    public function testInvalidHeaderConfig(): void
+    {
+        $dataDir = __DIR__ . '/data/invalidHeadersConfig';
+        $process = $this->startPhpProcess($dataDir);
+        $process->wait();
+        $stdout = $process->getOutput();
+        Assert::assertSame(1, $process->getExitCode());
+        Assert::assertStringContainsString(
+            'Invalid configuration: invalid type "object" in headers at path: Authorization.0',
+            $stdout
+        );
+    }
+
+    public function startPhpProcess(string $dataDir): Process
+    {
+        $outDir = $dataDir . '/out';
+        $runPhp = __DIR__ . '/../../src/run.php';
+        $this->rmDirs[] = $outDir;
+        $process = new Process(['php', "$runPhp"], null, ['KBC_DATADIR' => $dataDir]);
+        $process->setTimeout(60);
+        $process->start();
+        return $process;
+    }
+}

--- a/tests/phpunit/data/invalidHeadersConfig/config.json
+++ b/tests/phpunit/data/invalidHeadersConfig/config.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api": {
+      "baseUrl": "https://lichess.org/",
+      "http": {
+        "headers": {
+          "Authorization":
+                  [
+            {
+              "args": [
+                "Bearer ",
+                {
+                  "attr": "#token"
+                }
+              ],
+              "function": "concat"
+            }
+        ]
+        }
+      }
+    },
+    "config": {
+      "#token": "KBC::ProjectSecureKV::eJxLtDK2qs60MrIutjI0sLBSuveVieHfmSubrQLzfI88D9NVajxXcup9cT5vJH/N9W1zfp+Nkf7Pq3Fa7cy7iiMzF5gJySx3FzFNLYt9pPKCx1/Z/9bCk3JNG6zSJk1dK+g6tdLr7pq3m3j2pR1u5dt//cgehs86Lxd3rj1yXOnINY++SiXrTCtjoMVGZlZK6al5uql5yUWVBSX5RWbGKebJKYYmiWbGpqkgVSZAVcZGVkrJhomWKaaGhgZGZokmBolJFpaGycaJqRaWppZAloG5knUtAHCEU00=",
+      "debug": true,
+      "jobs": [
+        {
+          "dataField": ".",
+          "endpoint": "api/account"
+        }
+      ],
+      "outputBucket": "Player_Details"
+    }
+  }
+}


### PR DESCRIPTION
JIRA: https://keboola.atlassian.net/browse/CM-483

Vzhledem k tomu jak je konfigurace genericu modulární a volná, mi tohle přijde jako jediný řešení, checkovat to až v setování headers na hodnoty, které jsou pro Guzzle v headers nevalidní (`null|scalar|array` only). Navíc je to imho dost rare záležitost, blbě napsaný konfigurace a vůbec se nevyplatilo tomu věnovat tolik času, jak dlouho jsem to debugoval :-/