### PR TITLE
support for data as json object

### DIFF
--- a/python-sync-actions/src/component.py
+++ b/python-sync-actions/src/component.py
@@ -279,13 +279,8 @@ class Component(ComponentBase):
             except KeyError:
                 result = [f"Path {path.path} not found in the response data"]
 
-        # TODO: check if the result is list
         if result is None:
             result = ["No suitable array element found in the response data, please define the Data Selector path."]
-        if not isinstance(result, list):
-            element_name = 'root' if path.path == '.' else path.path
-            result = [f"The {element_name} element of the response is not a list, "
-                      f"please change your Data Selector path to list"]
 
         return result
 
@@ -390,7 +385,11 @@ class Component(ComponentBase):
             current_results = self._parse_data(self._final_response.json(), job.data_path)
 
             if config_index == len(self._configurations) - 1:
-                final_results.extend(current_results)
+                if isinstance(current_results, list):
+                    final_results.extend(current_results)
+                else:
+                    final_results.append(current_results)
+
             else:
                 if isinstance(current_results, list):
                     # limit the number of calls to 10 because of timeout

--- a/python-sync-actions/tests/test_component.py
+++ b/python-sync-actions/tests/test_component.py
@@ -3,6 +3,7 @@ import unittest
 from pathlib import Path
 
 from component import Component
+from configuration import DataPath
 
 
 class TestComponent(unittest.TestCase):
@@ -128,6 +129,16 @@ class TestComponent(unittest.TestCase):
                 "data": [[{"col": "a"}], [{"col": "b"}]]
                 }
         results = component._parse_data(data, None)
+        self.assertEqual(results, data['data'])
+
+    def test_parse_object_instead_of_list(self):
+        component = self._get_test_component('test_009_empty_datafield')
+        # test array of primitives
+        data = {"some_property": "asd",
+                "some_object": {"some_property": "asd"},
+                "data": {"id": 1, "name": "John"}
+                }
+        results = component._parse_data(data, DataPath("data"))
         self.assertEqual(results, data['data'])
 
 


### PR DESCRIPTION
- removed the check validating that the result is a list
- extend only when the data is a list, otherwise append.
- added a test