### PR TITLE
chore: bump keboola-json-to-csv to 0.0.13

### DIFF
--- a/python-sync-actions/requirements.in
+++ b/python-sync-actions/requirements.in
@@ -2,7 +2,7 @@ keboola.component
 dataconf
 keboola.http-client
 keboola.utils
-keboola.json-to-csv==0.0.12
+keboola.json-to-csv==0.0.13
 mock==5.1.0
 freezegun==1.5.1
 nested-lookup==0.2.25

--- a/python-sync-actions/requirements.txt
+++ b/python-sync-actions/requirements.txt
@@ -20,7 +20,7 @@ keboola-component==1.6.8
     # via -r requirements.txt
 keboola-http-client==1.0.1
     # via -r requirements.txt
-keboola-json-to-csv==0.0.12
+keboola-json-to-csv==0.0.13
     # via -r requirements.txt
 keboola-utils==1.1.0
     # via -r requirements.txt


### PR DESCRIPTION
# chore: bump keboola-json-to-csv to 0.0.13

## Summary

Bumps `keboola-json-to-csv` from `0.0.12` to `0.0.13` in `python-sync-actions`. Version `0.0.13` contains the fix for [SUPPORT-15504](https://keboola.atlassian.net/browse/SUPPORT-15504) — a `TypeError: argument of type 'NodeType' is not iterable` crash in the "Infer Mapping" sync action caused by using `in` instead of `==` for an enum comparison in the JSON analyzer.

Upstream fix PR: https://github.com/keboola/python-json-to-csv/pull/14

## Review & Testing Checklist for Human

- [ ] **Test "Infer Mapping" with polymorphic JSON**: The fix enables a previously-unreachable code path (DICT → LIST type upgrade). Test with an API response where the same field is a dict in one row and a list in another to verify the crash no longer occurs and the inferred mapping is correct.
- [ ] Verify `0.0.13` is [available on PyPI](https://pypi.org/project/keboola.json-to-csv/0.0.13/)

### Notes
- Link to Devin session: https://app.devin.ai/sessions/cb968c61c84b4ee68c805852c52466a6
- Requested by: @Jakuboola

[SUPPORT-15504]: https://keboola.atlassian.net/browse/SUPPORT-15504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/generic-extractor/pull/207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
