### PR TITLE
chore: bump keboola-json-to-csv to 0.0.14

### DIFF
--- a/python-sync-actions/requirements.in
+++ b/python-sync-actions/requirements.in
@@ -2,7 +2,7 @@ keboola.component
 dataconf
 keboola.http-client
 keboola.utils
-keboola.json-to-csv==0.0.13
+keboola.json-to-csv==0.0.14
 mock==5.1.0
 freezegun==1.5.1
 nested-lookup==0.2.25

--- a/python-sync-actions/requirements.txt
+++ b/python-sync-actions/requirements.txt
@@ -20,7 +20,7 @@ keboola-component==1.6.8
     # via -r requirements.txt
 keboola-http-client==1.0.1
     # via -r requirements.txt
-keboola-json-to-csv==0.0.13
+keboola-json-to-csv==0.0.14
     # via -r requirements.txt
 keboola-utils==1.1.0
     # via -r requirements.txt


### PR DESCRIPTION
## Summary

Bumps `keboola-json-to-csv` from `0.0.13` to `0.0.14` in the python-sync-actions dependencies.

`0.0.14` fixes an `AttributeError: 'NoneType' object has no attribute 'items'` crash in `analyzer.py:88` when a JSON field is a dict in one row but `null` in another during "Infer Mapping". This was the second bug discovered in the same code path after the `0.0.13` fix (NodeType enum `in` vs `==`) unblocked it.

Upstream fix: https://github.com/keboola/python-json-to-csv/pull/16

## Review & Testing Checklist for Human

- [ ] **End-to-end test**: After deploying, test "Infer Mapping" with an API response containing a field that is a dict in some rows and `null` in others — this was the exact crash scenario
- [ ] Verify the upstream fix in [python-json-to-csv PR #16](https://github.com/keboola/python-json-to-csv/pull/16) looks correct (single-line guard: `and value is not None`)

### Notes
- Link to Devin session: https://app.devin.ai/sessions/cb968c61c84b4ee68c805852c52466a6
- Requested by: @Jakuboola
- Follows PR #207 which bumped the same dependency from 0.0.12 → 0.0.13